### PR TITLE
Adds a 'trigger' mode to kick off another build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
 # GitHub Pull Request Plugin
 
-A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to checkout the GitHub post-merge check PR ref (`refs/pull/123/merge`) rather than building the branch `HEAD`.
+A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) to help build the GitHub post-merge check PR ref (`refs/pull/123/merge`).
 
-This ensures tests run against the "merged" branch, helping catch bad merges.
+This plugin helps you run CI run against the "merged" branch, helping catch bad merges.
+
+The plugin has two modes:
+  - `mode: trigger` to async trigger another build (of the current pipeline); and
+  - `mode: checkout` to checkout the PR merged ref (`refs/pull/123/merge`) rather than the head (`refs/pull/123/head`)
 
 ## Example
 
 ```yml
 steps:
   - plugins:
-      zsims/github-merged-pr#v0.0.4: ~
+      zsims/github-merged-pr#v0.0.5:
+        mode: checkout
+```
+
+```yml
+steps:
+  - plugins:
+      zsims/github-merged-pr#v0.0.5:
+        mode: trigger
 ```
 
 Ensure `Skip pull request builds for existing commits` is set to `false` in your Pipeline settings, as BuildKite will build the branch and skip the PR build.

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -2,10 +2,40 @@
 
 set -euo pipefail
 
-if [[ -n "${BUILDKITE_PULL_REQUEST}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] ; then
+mode="checkout"
+if [[ -v BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE ]]; then
+  mode="${BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE}"
+fi
+
+function trigger_merged_build() {
+  local slug="${BUILDKITE_PIPELINE_SLUG}"
+  local pr="${BUILDKITE_PULL_REQUEST}"
+  local ref="refs/pull/${pr}/merge"
+  echo "--- Triggering merged build of ${slug} for PR ${pr} (ref ${ref})"
+  cat <<EOL | buildkite-agent pipeline upload 
+  - label: "Merge build"
+    trigger: "${slug}"
+    build:
+      message: "Merge build for Pull Request ${pr}"
+      branch: "${ref}"
+EOL
+}
+
+function update_ref_to_merged() {
   # Setting BUILDKITE_REFSPEC will avoid other checkout behavior: https://github.com/buildkite/agent/blob/3b979f044ec7321470a8b1d742eee23ad4f31bce/templates/bootstrap.sh#L288
   export BUILDKITE_REFSPEC="refs/pull/${BUILDKITE_PULL_REQUEST}/merge"
   echo "--- Setting BUILDKITE_REFSPEC to ${BUILDKITE_REFSPEC}"
+}
+
+if [[ -n "${BUILDKITE_PULL_REQUEST}" && "${BUILDKITE_PULL_REQUEST}" != "false" ]] ; then
+  if [[ "$mode" == "checkout" ]]; then
+    update_ref_to_merged
+  elif [[ "$mode" == "trigger" ]]; then
+    trigger_merged_build
+  else
+    echo "--- Invalid mode: $mode"
+    exit 1
+  fi
 else
   echo "--- No BUILDKITE_PULL_REQUEST variable set, using default checkout behavior"
 fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -15,6 +15,7 @@ function trigger_merged_build() {
   cat <<EOL | buildkite-agent pipeline upload 
   - label: "Merge build"
     trigger: "${slug}"
+    async: true
     build:
       message: "Merge build for Pull Request ${pr}"
       branch: "${ref}"

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -13,6 +13,22 @@ pre_checkout_hook="$PWD/hooks/pre-checkout"
   assert_output --partial "Setting BUILDKITE_REFSPEC to refs/pull/123/merge"
 }
 
+@test "Triggers a build if PR number set and mode is trigger" {
+  export BUILDKITE_PULL_REQUEST=123
+  export BUILDKITE_PLUGIN_GITHUB_MERGED_PR_MODE="trigger"
+  export BUILDKITE_PIPELINE_SLUG="my-pipeline"
+
+  stub buildkite-agent \
+    "pipeline upload : echo UPLOADED_PIPELINE"
+
+  run "$pre_checkout_hook"
+
+  assert_success
+  assert_output --partial "Triggering merged build of my-pipeline for PR 123"
+  assert_output --partial "UPLOADED_PIPELINE"
+  unstub buildkite-agent
+}
+
 @test "Does nothing if no PR number set" {
   export BUILDKITE_PULL_REQUEST=""
 


### PR DESCRIPTION
As recommended by support (<3) this means another build can be kicked off to get accurate UI integration.